### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "gatsby-plugin-twitter": "^2.0.13",
     "i": "^0.3.6",
     "node-sass": "^4.11.0",
-    "npm": "^6.9.0",
     "prop-types": "latest",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",


### PR DESCRIPTION

Hello Sassi360!

It seems like you have npm as one of your (dev-) dependency in 2019-Portfolio.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
